### PR TITLE
Fix line contains point method

### DIFF
--- a/source/Metron/Shape/Line.swift
+++ b/source/Metron/Shape/Line.swift
@@ -129,8 +129,14 @@ public extension Line {
     /// - returns: True when the provided point is on this `Line`.
     /// - note: An error margin of 1e-12 is allowed.
     public func contains(_ point: CGPoint) -> Bool {
-        guard let pointAtX = self.point(atX: point.x) else { return false }
-        return point.distance(to: pointAtX) <= 1e-12
+        switch definition {
+        case .sloped:
+            guard let pointAtX = self.point(atX: point.x) else { return false }
+            return point.distance(to: pointAtX) <= 1e-12
+
+        case let .vertical(x):
+            return point.x == x
+        }
     }
 
     /// - returns: The intersection of this `Line` with the provided `Line`.


### PR DESCRIPTION
Fixes #15. When a line is defined as vertical line, the `contains` method returned false, even though the given point is contained within the line. The fix for this issue considers both definition types and checks whether the x-position matches with the x-coordinate of the given point. If this is the case it is guranteed that the given point is contained in the line. 